### PR TITLE
fix(android): Ringtone/Vibration stopping on auto lock

### DIFF
--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingActivity.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitIncomingActivity.kt
@@ -111,6 +111,7 @@ class CallkitIncomingActivity : Activity() {
                 IntentFilter("${packageName}.${ACTION_ENDED_CALL_INCOMING}")
             )
         }
+        FlutterCallkitIncomingPlugin.getInstance()?.getCallkitSoundPlayerManager()?.keepRingingOnFullScreen();
     }
 
     private fun wakeLockRequest(duration: Long) {

--- a/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitSoundPlayerManager.kt
+++ b/android/src/main/kotlin/com/hiennv/flutter_callkit_incoming/CallkitSoundPlayerManager.kt
@@ -9,8 +9,14 @@ import android.media.AudioManager
 import android.media.Ringtone
 import android.media.RingtoneManager
 import android.net.Uri
-import android.os.*
+import android.os.Build
+import android.os.Bundle
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
 import android.text.TextUtils
+import java.util.Timer
+import java.util.TimerTask
 
 class CallkitSoundPlayerManager(private val context: Context) {
 
@@ -21,16 +27,19 @@ class CallkitSoundPlayerManager(private val context: Context) {
 
     private var isPlaying: Boolean = false
 
+    private var keepRingingForFullScreenIntent: Boolean = false
+
 
     inner class ScreenOffCallkitIncomingBroadcastReceiver : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
-            if (isPlaying){
+            if (isPlaying && !keepRingingForFullScreenIntent) {
                 stop()
             }
         }
     }
 
-    private var screenOffCallkitIncomingBroadcastReceiver = ScreenOffCallkitIncomingBroadcastReceiver()
+    private var screenOffCallkitIncomingBroadcastReceiver =
+        ScreenOffCallkitIncomingBroadcastReceiver()
 
 
     fun play(data: Bundle) {
@@ -52,7 +61,8 @@ class CallkitSoundPlayerManager(private val context: Context) {
         vibrator = null
         try {
             context.unregisterReceiver(screenOffCallkitIncomingBroadcastReceiver)
-        }catch (_: Exception){}
+        } catch (_: Exception) {
+        }
     }
 
     fun destroy() {
@@ -64,7 +74,8 @@ class CallkitSoundPlayerManager(private val context: Context) {
         vibrator = null
         try {
             context.unregisterReceiver(screenOffCallkitIncomingBroadcastReceiver)
-        }catch (_: Exception){}
+        } catch (_: Exception) {
+        }
     }
 
     private fun prepare() {
@@ -118,12 +129,12 @@ class CallkitSoundPlayerManager(private val context: Context) {
             ringtone = RingtoneManager.getRingtone(context, uri)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 val attribution = AudioAttributes.Builder()
-                .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-                .setUsage(AudioAttributes.USAGE_NOTIFICATION_RINGTONE)
-                .setLegacyStreamType(AudioManager.STREAM_RING)
-                .build()
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                    .setUsage(AudioAttributes.USAGE_NOTIFICATION_RINGTONE)
+                    .setLegacyStreamType(AudioManager.STREAM_RING)
+                    .build()
                 ringtone?.setAudioAttributes(attribution)
-            }else {
+            } else {
                 ringtone?.streamType = AudioManager.STREAM_RING
             }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
@@ -139,7 +150,7 @@ class CallkitSoundPlayerManager(private val context: Context) {
         if (TextUtils.isEmpty(fileName)) {
             return getDefaultRingtoneUri()
         }
-        
+
         // If system_ringtone_default is explicitly requested, bypass resource check
         if (fileName.equals("system_ringtone_default", true)) {
             return getDefaultRingtoneUri(useSystemDefault = true)
@@ -163,7 +174,8 @@ class CallkitSoundPlayerManager(private val context: Context) {
         try {
             if (!useSystemDefault) {
                 // First try to use ringtone_default resource if it exists
-                val resId = context.resources.getIdentifier("ringtone_default", "raw", context.packageName)
+                val resId =
+                    context.resources.getIdentifier("ringtone_default", "raw", context.packageName)
                 if (resId != 0) {
                     return Uri.parse("android.resource://${context.packageName}/$resId")
                 }
@@ -211,5 +223,21 @@ class CallkitSoundPlayerManager(private val context: Context) {
             e.printStackTrace()
         }
         return null
+    }
+
+    private var ringingTimer: Timer? = null
+
+    // This function is called when the incoming call full intent (CallkitIncomingActivity) is shown
+    // It prevents the sound from stopping when the screen is turned off because of an auto lock
+    fun keepRingingOnFullScreen() {
+        keepRingingForFullScreenIntent = true
+        ringingTimer?.cancel()
+        ringingTimer = Timer().apply {
+            schedule(object : TimerTask() {
+                override fun run() {
+                    keepRingingForFullScreenIntent = false
+                }
+            }, 500)
+        }
     }
 }


### PR DESCRIPTION
### Description
When an incoming call notification was presented in a form of a heads-up notification, if the device auto locked when ringing, the ringtone /vibration stopped even though the fullscreen intent was presented.

**Many different solutions were attempted to fix this:**
- Use newWakeLock on the PowerManager to avoid the auto lock when presenting the heads-up notification. Even though this worked well, this is a deprecated method and it could be dangerous to use this method in a public plugin.
- We tried to add a transparent activity that would have the FLAG_KEEP_SCREEN_ON set to true and present it when showing the heads-up notification, but this only worked when the notification was booted when having the application in foreground.

**After some other solutions were attempted, here is the final one:**
Instead of trying to avoid the auto lock, we decided to keep the ringtone/vibration on when the phone auto locks and presents the fullscreen intent activity. To do this, we had to avoid stopping it during 200ms after the fullscreen intent is presented since the plugin is already stopped by the ACTION_SCREEN_OFF intent. This is a bit hackish but there is unfortunately no way to distinguish between an auto lock and a manual press on the power button of the device.

The only downside of the fix is that if a heads-up notification is presented and the user press on the power button, he will need to press it once again when being presented with the fullscreen intent to stop the ringtone/vibration. Still, the press on the power button when the phone is locked will stop the ringtone/vibration.